### PR TITLE
feat(cognito): :sparkles: Add access token hash and user info to Cognito tokens

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,8 @@ const config = {
 	testPathIgnorePatterns: ["coverage", "node_modules", "dist"],
 	transform: {
 		"\\.(ts)$": "ts-jest"
-	}
+	},
+	coveragePathIgnorePatterns: ["src/constants", "src/types"]
 };
 
 module.exports = config;

--- a/src/awsServices/cognito/cognito.ts
+++ b/src/awsServices/cognito/cognito.ts
@@ -1,108 +1,57 @@
-import urlJoin from "url-join";
-
-import { getSignedJwt } from "../../utils/getSignedJwt";
-import { GetCognitoTokensProps } from "../../types/awsServices/cognito/cognito";
-import { getUUID } from "../../utils";
 import {
-	ACCESS_TOKEN_SORTED_KEYS,
-	DEFAULT_COGNITO_CONFIG,
-	ID_TOKEN_SORTED_KEYS
-} from "../../constants/awsServices/cognito";
+	CognitoTokens,
+	GetCognitoTokensProps
+} from "../../types/awsServices/cognito/cognito";
+import { getUUID } from "../../utils";
+import { DEFAULT_COGNITO_CONFIG } from "../../constants/awsServices/cognito";
 import { getBaseJwtPayload } from "../../utils/getBaseJwtPayload";
-import { sortObjectKeys } from "../../utils/sortObjectKeys";
+import { getAccessToken } from "../../helpers/cognito/getAccessToken";
+import { getAccessTokenHash } from "../../helpers/cognito/getAccessTokenHash";
+import { getIDToken } from "../../helpers/cognito/getIDToken";
+import { getIssuerUrl } from "../../helpers/cognito/getIssuerUrl";
 
 export const getCognitoTokens = ({
 	asymmetricKeys,
 	user,
-	cognito,
-	userPool
-}: GetCognitoTokensProps): {
-	id_token: string;
-	access_token: string;
-} => {
-	const {
-		emailId,
-		uuid: cognitoUsername = getUUID(),
-		emailVerified = true
-	} = user;
+	cognito = {},
+	userPool = {}
+}: GetCognitoTokensProps): CognitoTokens => {
+	const userData = {
+		uuid: getUUID(),
+		emailVerified: true,
+		...user
+	};
 
-	const {
-		groups: cognitoGroups = ["admin"],
-		roles: cognitoRoles = ["arn:aws:iam::123456789012:role/admin"],
-		preferredRole:
-			cognitoPreferredRole = "arn:aws:iam::123456789012:role/admin",
-		scope: cognitoScope = DEFAULT_COGNITO_CONFIG.SCOPE,
-		clientId: userPoolClientId = DEFAULT_COGNITO_CONFIG.CLIENT_ID
-	} = cognito || {};
+	const cognitoData = {
+		groups: ["admin"],
+		roles: ["arn:aws:iam::123456789012:role/admin"],
+		scope: DEFAULT_COGNITO_CONFIG.SCOPE,
+		clientId: DEFAULT_COGNITO_CONFIG.CLIENT_ID,
+		...cognito
+	};
 
-	const {
-		id: userPoolId = DEFAULT_COGNITO_CONFIG.USER_POOL_ID,
-		region: userPoolRegion = DEFAULT_COGNITO_CONFIG.REGION
-	} = userPool || {};
+	const issuerUrl = getIssuerUrl(userPool);
+	const baseJwtPayload = getBaseJwtPayload({
+		issuer: issuerUrl,
+		subject: userData.uuid
+	});
 
-	const issuerUrl = urlJoin(
-		`https://cognito-idp.${userPoolRegion}.amazonaws.com`,
-		userPoolId
-	);
+	const accessToken = getAccessToken(asymmetricKeys, {
+		baseJwtPayload,
+		userData,
+		cognitoData
+	});
+	const accessTokenHash = getAccessTokenHash(accessToken);
 
-	const tokens = [
-		{
-			name: "id_token",
-			payload: {
-				email: emailId,
-				email_verified: emailVerified,
-				aud: userPoolClientId,
-				token_use: "id",
-				"cognito:username": cognitoUsername,
-				"cognito:groups": cognitoGroups,
-				"cognito:roles": cognitoRoles,
-				"cognito:preferred_role": cognitoPreferredRole,
-				...getBaseJwtPayload({
-					issuer: issuerUrl,
-					subject: cognitoUsername
-				})
-			},
-			order: ID_TOKEN_SORTED_KEYS
-		},
-		{
-			name: "access_token",
-			payload: {
-				scope: cognitoScope,
-				client_id: userPoolClientId,
-				token_use: "access",
-				username: cognitoUsername,
-				"cognito:groups": cognitoGroups,
-				...getBaseJwtPayload({
-					issuer: issuerUrl,
-					subject: cognitoUsername
-				})
-			},
-			order: ACCESS_TOKEN_SORTED_KEYS
-		}
-	];
+	const idToken = getIDToken(asymmetricKeys, {
+		baseJwtPayload,
+		accessTokenHash,
+		userData,
+		cognitoData
+	});
 
-	const cognitoTokens = tokens.reduce(
-		(acc, token) => {
-			const { name, payload, order } = token;
-
-			const sortedPayload = sortObjectKeys(payload, order);
-
-			const signedToken = getSignedJwt({
-				payload: sortedPayload,
-				secret: asymmetricKeys.pem.privateKey,
-				options: {
-					keyid: asymmetricKeys.keyId,
-					algorithm: "RS256"
-				}
-			});
-
-			return {
-				...acc,
-				[name]: signedToken
-			};
-		},
-		{} as { id_token: string; access_token: string }
-	);
-
-	return cognitoTokens;
+	return {
+		id_token: idToken,
+		access_token: accessToken
+	};
 };

--- a/src/constants/awsServices/cognito.ts
+++ b/src/constants/awsServices/cognito.ts
@@ -6,20 +6,25 @@ export const DEFAULT_COGNITO_CONFIG = {
 };
 
 export const ID_TOKEN_SORTED_KEYS = [
+	"at_hash",
 	"sub",
 	"cognito:groups",
 	"email_verified",
 	"cognito:preferred_role",
 	"iss",
 	"cognito:username",
+	"given_name",
+	"middle_name",
 	"origin_jti",
 	"cognito:roles",
 	"aud",
+	"identities",
 	"event_id",
 	"token_use",
 	"auth_time",
 	"exp",
 	"iat",
+	"family_name",
 	"jti",
 	"email"
 ];

--- a/src/helpers/cognito/getAccessToken.ts
+++ b/src/helpers/cognito/getAccessToken.ts
@@ -1,0 +1,32 @@
+import { ACCESS_TOKEN_SORTED_KEYS } from "../../constants/awsServices/cognito";
+import { GetAccessTokenProps } from "../../types/helpers/cognito/getAcessToken";
+import { AsymmetricKeys } from "../../types/utils/getAsymmetricKeys";
+import { getSignedJwt } from "../../utils/getSignedJwt";
+import { sortObjectKeys } from "../../utils/sortObjectKeys";
+
+export const getAccessToken = (
+	asymmetricKeys: AsymmetricKeys,
+	{ baseJwtPayload, userData, cognitoData }: GetAccessTokenProps
+): string => {
+	const payload = {
+		...baseJwtPayload,
+		token_use: "access",
+		// User
+		username: userData.uuid,
+		// Cognito
+		scope: cognitoData.scope,
+		client_id: cognitoData.clientId,
+		"cognito:groups": cognitoData.groups
+	};
+
+	const sortedPayload = sortObjectKeys(payload, ACCESS_TOKEN_SORTED_KEYS);
+
+	return getSignedJwt({
+		payload: sortedPayload,
+		secret: asymmetricKeys.pem.privateKey,
+		options: {
+			keyid: asymmetricKeys.keyId,
+			algorithm: "RS256"
+		}
+	});
+};

--- a/src/helpers/cognito/getAccessTokenHash.ts
+++ b/src/helpers/cognito/getAccessTokenHash.ts
@@ -1,0 +1,24 @@
+import * as crypto from "crypto";
+
+/**
+ * Calculate the `at_hash` of an access token as per the OIDC specification
+ * @param accessToken
+ * @returns `at_hash` value of the access token
+ */
+export const getAccessTokenHash = (accessToken: string): string => {
+	const sha256Hash = crypto
+		.createHash("sha256")
+		.update(accessToken)
+		.digest("hex");
+
+	// Take the first 128 bits (16 bytes) and base64url encode it
+	const truncatedHash = sha256Hash.substring(0, 32); // 32 hex characters = 16 bytes
+
+	const base64urlEncoded = Buffer.from(truncatedHash, "hex")
+		.toString("base64")
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=/g, "");
+
+	return base64urlEncoded;
+};

--- a/src/helpers/cognito/getIDToken.ts
+++ b/src/helpers/cognito/getIDToken.ts
@@ -1,0 +1,40 @@
+import { ID_TOKEN_SORTED_KEYS } from "../../constants/awsServices/cognito";
+import { GetIDTokenProps } from "../../types/helpers/cognito/getIDToken";
+import { AsymmetricKeys } from "../../types/utils/getAsymmetricKeys";
+import { getSignedJwt } from "../../utils/getSignedJwt";
+import { sortObjectKeys } from "../../utils/sortObjectKeys";
+
+export const getIDToken = (
+	asymmetricKeys: AsymmetricKeys,
+	{ baseJwtPayload, accessTokenHash, userData, cognitoData }: GetIDTokenProps
+): string => {
+	const payload = {
+		...baseJwtPayload,
+		at_hash: accessTokenHash,
+		token_use: "id",
+		// User
+		email: userData.emailId,
+		email_verified: userData.emailVerified,
+		given_name: userData.givenName,
+		middle_name: userData.middleName,
+		family_name: userData.familyName,
+		identities: userData.identities,
+		"cognito:username": userData.uuid,
+		// Cognito
+		aud: cognitoData.clientId,
+		"cognito:groups": cognitoData.groups,
+		"cognito:roles": cognitoData.roles,
+		"cognito:preferred_role": cognitoData.preferredRole
+	};
+
+	const sortedPayload = sortObjectKeys(payload, ID_TOKEN_SORTED_KEYS);
+
+	return getSignedJwt({
+		payload: sortedPayload,
+		secret: asymmetricKeys.pem.privateKey,
+		options: {
+			keyid: asymmetricKeys.keyId,
+			algorithm: "RS256"
+		}
+	});
+};

--- a/src/helpers/cognito/getIssuerUrl.ts
+++ b/src/helpers/cognito/getIssuerUrl.ts
@@ -1,0 +1,16 @@
+import urljoin from "url-join";
+
+import { DEFAULT_COGNITO_CONFIG } from "../../constants/awsServices/cognito";
+import { UserPool } from "../../types/awsServices/cognito/cognito";
+
+export const getIssuerUrl = (userPool: UserPool): string => {
+	const {
+		id: userPoolId = DEFAULT_COGNITO_CONFIG.USER_POOL_ID,
+		region: userPoolRegion = DEFAULT_COGNITO_CONFIG.REGION
+	} = userPool;
+
+	return urljoin(
+		`https://cognito-idp.${userPoolRegion}.amazonaws.com`,
+		userPoolId
+	);
+};

--- a/src/types/awsServices/cognito/cognito.ts
+++ b/src/types/awsServices/cognito/cognito.ts
@@ -1,19 +1,52 @@
 import { AsymmetricKeys } from "../../utils/getAsymmetricKeys";
 
-interface GetCognitoTokensProps {
-	asymmetricKeys: AsymmetricKeys;
-	user: { emailId: string; uuid?: string; emailVerified?: boolean };
-	cognito?: {
-		groups?: string[];
-		roles?: string[];
-		preferredRole?: string;
-		scope?: string;
-		clientId?: string;
-	};
-	userPool?: {
-		id?: string;
-		region?: string;
-	};
+interface CognitoIdentity {
+	userId: string;
+	providerName: string;
+	providerType: string;
+	issuer: string;
+	primary: string;
+	dateCreated: string;
+}
+interface User {
+	emailId: string;
+	givenName?: string;
+	middleName?: string;
+	familyName?: string;
+	uuid?: string;
+	emailVerified?: boolean;
+	identities?: CognitoIdentity[];
 }
 
-export { GetCognitoTokensProps };
+interface Cognito {
+	groups?: string[];
+	roles?: string[];
+	preferredRole?: string;
+	scope?: string;
+	clientId?: string;
+}
+
+interface UserPool {
+	id?: string;
+	region?: string;
+}
+
+interface GetCognitoTokensProps {
+	asymmetricKeys: AsymmetricKeys;
+	user: User;
+	cognito?: Cognito;
+	userPool?: UserPool;
+}
+
+interface CognitoTokens {
+	id_token: string;
+	access_token: string;
+}
+
+export { User, Cognito, UserPool, CognitoIdentity };
+
+/**
+ * External exports
+ * Update `src/types/index.ts`
+ */
+export { CognitoTokens, GetCognitoTokensProps };

--- a/src/types/helpers/cognito/getAcessToken.ts
+++ b/src/types/helpers/cognito/getAcessToken.ts
@@ -1,0 +1,10 @@
+import { User, Cognito } from "../../awsServices/cognito/cognito";
+import { BaseJwtPayload } from "../../utils/getBaseJwtPayload";
+
+interface GetAccessTokenProps {
+	baseJwtPayload: BaseJwtPayload;
+	userData: User & { uuid: string };
+	cognitoData: Cognito;
+}
+
+export { GetAccessTokenProps };

--- a/src/types/helpers/cognito/getIDToken.ts
+++ b/src/types/helpers/cognito/getIDToken.ts
@@ -1,0 +1,11 @@
+import { User, Cognito } from "../../awsServices/cognito/cognito";
+import { BaseJwtPayload } from "../../utils/getBaseJwtPayload";
+
+interface GetIDTokenProps {
+	baseJwtPayload: BaseJwtPayload;
+	accessTokenHash: string;
+	userData: User;
+	cognitoData: Cognito;
+}
+
+export { GetIDTokenProps };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,4 @@
-export type { GetCognitoTokensProps } from "./awsServices/cognito/cognito";
+export type {
+	CognitoTokens,
+	GetCognitoTokensProps
+} from "./awsServices/cognito/cognito";

--- a/tests/unit/helpers/cognito/getAccessToken.test.ts
+++ b/tests/unit/helpers/cognito/getAccessToken.test.ts
@@ -1,0 +1,55 @@
+import * as jwt from "jsonwebtoken";
+
+import { getAccessToken } from "../../../../src/helpers/cognito/getAccessToken";
+import { getAsymmetricKeys } from "../../../../src/utils";
+import { getBaseJwtPayload } from "../../../../src/utils/getBaseJwtPayload";
+
+describe("unit::helpers::cognito::getAccessToken", () => {
+	it("should return the access token", () => {
+		const asymmetricKeys = getAsymmetricKeys();
+		const baseJwtPayload = getBaseJwtPayload({
+			issuer: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_123456789",
+			subject: "1234567890"
+		});
+
+		const accessToken = getAccessToken(asymmetricKeys, {
+			baseJwtPayload,
+			userData: {
+				emailId: "test-email-id",
+				uuid: "test-uuid"
+			},
+			cognitoData: {
+				groups: ["test-cognito-group"]
+			}
+		});
+
+		let payload: string | jwt.JwtPayload | null = null;
+		try {
+			payload = jwt.verify(accessToken, asymmetricKeys.pem.publicKey);
+		} catch (error) {
+			expect(error).toBeNull();
+		}
+		expect(payload).not.toBeNull();
+
+		const expected = {
+			sub: "1234567890",
+			"cognito:groups": ["test-cognito-group"],
+			iss: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_123456789",
+			origin_jti: baseJwtPayload.origin_jti,
+			event_id: baseJwtPayload.event_id,
+			token_use: "access",
+			auth_time: baseJwtPayload.auth_time,
+			exp: baseJwtPayload.exp,
+			iat: baseJwtPayload.iat,
+			jti: baseJwtPayload.jti,
+			username: "test-uuid"
+		};
+
+		// Check if the order of the keys are the same
+		const keysPayload = Object.keys(payload as jwt.JwtPayload);
+		const keysExpected = Object.keys(expected);
+		expect(keysPayload).toEqual(keysExpected);
+
+		expect(payload).toEqual(expected);
+	});
+});

--- a/tests/unit/helpers/cognito/getAccessTokenHash.test.ts
+++ b/tests/unit/helpers/cognito/getAccessTokenHash.test.ts
@@ -1,0 +1,12 @@
+import { getAccessTokenHash } from "../../../../src/helpers/cognito/getAccessTokenHash";
+
+describe("unit::helpers::cognito::getAccessTokenHash", () => {
+	it("should return the access token hash", () => {
+		const accessToken = "temp-access-token";
+		const expectedHash = "3T4fHBWhxfYrKhSb6BD_dg";
+
+		const result = getAccessTokenHash(accessToken);
+
+		expect(result).toBe(expectedHash);
+	});
+});

--- a/tests/unit/helpers/cognito/getIDToken.test.ts
+++ b/tests/unit/helpers/cognito/getIDToken.test.ts
@@ -1,0 +1,61 @@
+import * as jwt from "jsonwebtoken";
+
+import { getIDToken } from "../../../../src/helpers/cognito/getIDToken";
+import { getAsymmetricKeys } from "../../../../src/utils";
+import { getBaseJwtPayload } from "../../../../src/utils/getBaseJwtPayload";
+
+describe("getIDToken", () => {
+	it("should return a valid ID token", () => {
+		const asymmetricKeys = getAsymmetricKeys();
+		const issuer =
+			"https://cognito-idp.us-east-1.amazonaws.com/us-east-1_123456789";
+		const subject = "1234567890";
+		const baseJwtPayload = getBaseJwtPayload({
+			issuer,
+			subject
+		});
+
+		const idToken = getIDToken(asymmetricKeys, {
+			baseJwtPayload,
+			accessTokenHash: "test-access-token-hash",
+			userData: {
+				emailId: "test-email-id",
+				uuid: "test-uuid"
+			},
+			cognitoData: {
+				groups: ["test-cognito-group"]
+			}
+		});
+
+		let payload: string | jwt.JwtPayload | null = null;
+		try {
+			payload = jwt.verify(idToken, asymmetricKeys.pem.publicKey);
+		} catch (error) {
+			expect(error).toBeNull();
+		}
+		expect(payload).not.toBeNull();
+
+		const expected = {
+			at_hash: "test-access-token-hash",
+			sub: "1234567890",
+			"cognito:groups": ["test-cognito-group"],
+			iss: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_123456789",
+			"cognito:username": "test-uuid",
+			origin_jti: baseJwtPayload.origin_jti,
+			event_id: baseJwtPayload.event_id,
+			token_use: "id",
+			auth_time: baseJwtPayload.auth_time,
+			exp: baseJwtPayload.exp,
+			iat: baseJwtPayload.iat,
+			jti: baseJwtPayload.jti,
+			email: "test-email-id"
+		};
+
+		// Check if the order of the keys are the same
+		const keysPayload = Object.keys(payload as jwt.JwtPayload);
+		const keysExpected = Object.keys(expected);
+		expect(keysPayload).toEqual(keysExpected);
+
+		expect(payload).toEqual(expected);
+	});
+});

--- a/tests/unit/helpers/cognito/getIssuerUrl.test.ts
+++ b/tests/unit/helpers/cognito/getIssuerUrl.test.ts
@@ -1,0 +1,25 @@
+import { getIssuerUrl } from "../../../../src/helpers/cognito/getIssuerUrl";
+
+describe("unit::helpers::cognito::getIssuerUrl", () => {
+	it("should return the issuer URL with custom config", () => {
+		const id = "temp-id";
+		const region = "temp-region";
+
+		const result = getIssuerUrl({
+			id,
+			region
+		});
+
+		expect(result).toBe(
+			`https://cognito-idp.${region}.amazonaws.com/${id}`
+		);
+	});
+
+	it("should return the issuer URL with default config", () => {
+		const result = getIssuerUrl({});
+
+		expect(result).toBe(
+			"https://cognito-idp.us-east-1.amazonaws.com/us-east-1_A1b2C3d4E"
+		);
+	});
+});

--- a/tests/unit/utils/sortObjectKeys.test.ts
+++ b/tests/unit/utils/sortObjectKeys.test.ts
@@ -14,7 +14,8 @@ describe("sortObjectKeys", () => {
 
 		const sortedObj = sortObjectKeys<TestObject>(obj, keyOrder);
 
-		expect(sortedObj).toMatchObject(obj);
+		expect(Object.keys(sortedObj)).toEqual(Object.keys(obj));
+		expect(sortedObj).toEqual(obj);
 	});
 
 	it("should return the object with the keys sorted based on the order", () => {
@@ -27,11 +28,13 @@ describe("sortObjectKeys", () => {
 
 		const sortedObj = sortObjectKeys<TestObject>(obj, keyOrder);
 
-		expect(sortedObj).toMatchObject({
+		const expectedObj = {
 			key3: "value3",
 			key1: "value1",
 			key2: "value2"
-		});
+		};
+		expect(Object.keys(sortedObj)).toEqual(Object.keys(expectedObj));
+		expect(sortedObj).toEqual(expectedObj);
 	});
 
 	it("should return the object with the keys sorted based on the order and maintain the original order for keys not in the order", () => {
@@ -46,12 +49,14 @@ describe("sortObjectKeys", () => {
 
 		const sortedObj = sortObjectKeys<TestObject>(obj, keyOrder);
 
-		expect(sortedObj).toMatchObject({
+		const expectedObj = {
 			key3: "value3",
 			key1: "value1",
 			key2: "value2",
 			key5: "value5",
 			key4: "value4"
-		});
+		};
+		expect(Object.keys(sortedObj)).toEqual(Object.keys(expectedObj));
+		expect(sortedObj).toEqual(expectedObj);
 	});
 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,27 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ES2022",
+		"moduleResolution": "node",
+		"declaration": true,
+		"declarationMap": true,
+		"outDir": "dist",
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"strictFunctionTypes": true,
+		"strictBindCallApply": true,
+		"strictPropertyInitialization": true,
+		"noImplicitThis": true,
+		"alwaysStrict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"skipLibCheck": true,
+		"typeRoots": ["node_modules/@types"]
+	},
+	"exclude": ["node_modules"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
 	"extends": "./tsconfig.base.json",
-	"include": ["./src", "./tests"]
+	"include": ["./src"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
 	shims: true,
 	skipNodeModulesBundle: true,
 	clean: true,
-	sourcemap: true
+	sourcemap: true,
+	tsconfig: "tsconfig.build.json"
 });


### PR DESCRIPTION

- Add access token hash to the ID token as per OIDC specification
- Added support for the name (first, middle & given) of the user
- Enhancements around code structure
- Fixed UT for sortObjectKeys
- Introduced a new naming convention for UTs `path::module`
- Separate tsconfig.json for build and development