### PR TITLE
fix: Dependabot group names

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,9 +9,9 @@ updates:
           - "ShellXploit"
       versioning-strategy: increase
       groups:
-          deps:
+          "Dependencies":
               dependency-type: "production"
-          dev-deps:
+          "Dev Dependencies":
               dependency-type: "development"
 
     - package-ecosystem: "github-actions"


### PR DESCRIPTION
Marking this as a `fix` instead of a `chore` to trigger a package release to NPM.