### PR TITLE
fix: workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: Node CI
 
+permissions:
+    contents: read
+    actions: write
+
 on:
     workflow_dispatch:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/ShellXploit/aws-mock-data/security/code-scanning/3](https://github.com/ShellXploit/aws-mock-data/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the tasks in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's contents during the `actions/checkout` step.
- `actions: write` for uploading coverage reports to Codecov.

The `permissions` block will be added after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
